### PR TITLE
More cleanup

### DIFF
--- a/lib/app_states/src/app_states.h
+++ b/lib/app_states/src/app_states.h
@@ -1,0 +1,54 @@
+
+#pragma once
+
+#include <Arduino.h>
+
+enum QueryState {
+  WAITING_TO_QUERY,
+  DNS_NOT_FOUND,
+  SSL_CONNECTION_FAILURE,
+  LAST_RESPONSE_PASS,
+  LAST_RESPONSE_FAIL,
+  LAST_RESPONSE_UNSURE,
+  NOT_AUTHENTICATED,
+};
+
+enum NotificationState {
+  NOTIFICATION_NOT_ATTEMPTED,
+  NOTIFICATIONS_SENT,
+  NOTIFICATION_ATTEMPT_FAILED,
+};
+
+String queryStateToString (QueryState state) {
+  switch (state) {
+    case WAITING_TO_QUERY:
+      return "WAITING_TO_QUERY";
+    case SSL_CONNECTION_FAILURE:
+      return "CONNECTION_FAILURE";
+    case DNS_NOT_FOUND:
+      return "DNS_NOT_FOUND";
+    case LAST_RESPONSE_PASS:
+      return "LAST_RESPONSE_PASS";
+    case LAST_RESPONSE_FAIL:
+      return "LAST_RESPONSE_FAIL";
+    case LAST_RESPONSE_UNSURE:
+      return "LAST_RESPONSE_UNSURE";
+    case NOT_AUTHENTICATED:
+      return "NOT_AUTHENTICATED";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+String notificationStateToString (NotificationState state) {
+  switch (state) {
+    case NOTIFICATION_NOT_ATTEMPTED:
+      return "NOTIFICATION_NOT_ATTEMPTED";
+    case NOTIFICATIONS_SENT:
+      return "NOTIFICATIONS_SENT";
+    case NOTIFICATION_ATTEMPT_FAILED:
+      return "NOTIFICATION_ATTEMPT_FAILED";
+    default:
+      return "UNKNOWN";
+  }
+}

--- a/lib/app_states/src/app_states.h
+++ b/lib/app_states/src/app_states.h
@@ -52,3 +52,27 @@ String notificationStateToString (NotificationState state) {
       return "UNKNOWN";
   }
 }
+
+/**
+ * @brief A class to lock the ESP32 frame buffer
+ *
+ * This class is used to lock the ESP32 frame buffer. It is used mainly for RAII, so that the frame buffer is properly released when the object goes out of scope.
+ * It's not a true lock, the pointer to the frame is freely accessbile
+ *
+ * @todo Implement this class
+ */
+class EspFrameLock {
+  public:
+    camera_fb_t* frame = NULL;
+
+    EspFrameLock() {
+      frame = esp_camera_fb_get();
+    }
+
+    ~EspFrameLock() {
+      esp_camera_fb_return(frame);
+      delete frame;
+    }
+     EspFrameLock& operator=(const EspFrameLock&) = delete; // disallow assignment
+     EspFrameLock(const EspFrameLock&) = delete; // disallow copying
+};

--- a/src/deployable_example.cpp
+++ b/src/deployable_example.cpp
@@ -24,14 +24,15 @@ SOFTWARE.
 
 */
 
-#include <Arduino.h>
+
 #include <Preferences.h>
-#include "WiFi.h"
+#include <WiFi.h>
 #include <esp_camera.h>
 #include <time.h>
-#include "ArduinoJson.h"
-#include "groundlight.h"
+#include <ArduinoJson.h>
 
+#include "groundlight.h"
+#include "app_states.h"
 #include "camera_pins.h" // thank you seeedstudio for this file
 #include "integrations.h"
 #include "stacklight.h"
@@ -55,75 +56,6 @@ uint8_t *frame_565_old;
 #define ALPHA_DIVISOR 10
 #define ALPHA FRAME_ARR_LEN / ALPHA_DIVISOR
 #define BETA 20 // out of 31
-
-enum QueryState {
-  WAITING_TO_QUERY,
-  DNS_NOT_FOUND,
-  SSL_CONNECTION_FAILURE,
-  LAST_RESPONSE_PASS,
-  LAST_RESPONSE_FAIL,
-  LAST_RESPONSE_UNSURE,
-  NOT_AUTHENTICATED,
-};
-
-String queryStateToString (QueryState state) {
-  switch (state) {
-    case WAITING_TO_QUERY:
-      return "WAITING_TO_QUERY";
-    case SSL_CONNECTION_FAILURE:
-      return "CONNECTION_FAILURE";
-    case DNS_NOT_FOUND:
-      return "DNS_NOT_FOUND";
-    case LAST_RESPONSE_PASS:
-      return "LAST_RESPONSE_PASS";
-    case LAST_RESPONSE_FAIL:
-      return "LAST_RESPONSE_FAIL";
-    case LAST_RESPONSE_UNSURE:
-      return "LAST_RESPONSE_UNSURE";
-    case NOT_AUTHENTICATED:
-      return "NOT_AUTHENTICATED";
-    default:
-      return "UNKNOWN";
-  }
-}
-
-enum NotificationState {
-  NOTIFICATION_NOT_ATTEMPTED,
-  NOTIFICATIONS_SENT,
-  NOTIFICATION_ATTEMPT_FAILED,
-};
-
-String notificationStateToString (NotificationState state) {
-  switch (state) {
-    case NOTIFICATION_NOT_ATTEMPTED:
-      return "NOTIFICATION_NOT_ATTEMPTED";
-    case NOTIFICATIONS_SENT:
-      return "NOTIFICATIONS_SENT";
-    case NOTIFICATION_ATTEMPT_FAILED:
-      return "NOTIFICATION_ATTEMPT_FAILED";
-    default:
-      return "UNKNOWN";
-  }
-}
-
-enum StacklightState {
-  STACKLIGHT_NOT_FOUND,
-  STACKLIGHT_ONLINE,
-  STACKLIGHT_PAIRED,
-};
-
-String stacklightStateToString (StacklightState state) {
-  switch (state) {
-    case STACKLIGHT_NOT_FOUND:
-      return "STACKLIGHT_NOT_FOUND";
-    case STACKLIGHT_ONLINE:
-      return "STACKLIGHT_ONLINE";
-    case STACKLIGHT_PAIRED:
-      return "STACKLIGHT_PAIRED";
-    default:
-      return "UNKNOWN";
-  }
-}
 
 QueryState queryState = WAITING_TO_QUERY;
 NotificationState notificationState = NOTIFICATION_NOT_ATTEMPTED;
@@ -248,7 +180,7 @@ bool decodeWorkingHoursString(String working_hours);
 
 bool should_deep_sleep() {
   return (query_delay > 29) && !disable_deep_sleep_for_notifications && !disable_deep_sleep_until_reset;
-} 
+}
 
 void deep_sleep() {
   int time_elapsed = millis() - last_upload_time;
@@ -532,7 +464,7 @@ void setup() {
     preferences.getString("api_key", groundlight_API_key, 75);
     preferences.getString("det_id", groundlight_det_id, 100);
     query_delay = preferences.getInt("query_delay", query_delay);
-    
+
     WiFi.begin(ssid, password);
     wifi_configured = true;
   }
@@ -732,6 +664,7 @@ void loop () {
     vTaskDelay(1000 / portTICK_PERIOD_MS);
   #endif
 
+  // TODO: figure out why we need to capture twice to get the latest image?
   frame = esp_camera_fb_get();
   // Testing how to get the latest image
   esp_camera_fb_return(frame);

--- a/src/stacklight.h
+++ b/src/stacklight.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <Arduino.h>
 #include "WiFi.h"
 #include <HTTPClient.h>
@@ -117,12 +119,12 @@ namespace Stacklight
 
     /**
      * @brief Try to connect to Stacklight AP and push WiFi credentials
-     * 
+     *
      * This happens over time, and not for initialization. Must be connected to the stacklight first.
-     * 
+     *
      * @param ssid WiFi SSID
      * @param password WiFi password
-     * 
+     *
      * @return Stacklight IP address (empty string if not connected)
     */
     String tryConnectToStacklight(const char * ssid, const char * password) {
@@ -133,18 +135,18 @@ namespace Stacklight
             vTaskDelay(1000 / portTICK_PERIOD_MS);
             pushWiFiCredToStacklight(ssid, password);
         }
-        
+
         return ip;
     }
 
     /**
      * @brief Try to connect to Stacklight AP and push WiFi credentials
-     * 
+     *
      * This is for initialization. Must be connected to the stacklight first.
-     * 
+     *
      * @param ssid WiFi SSID
      * @param password WiFi password
-     * 
+     *
      * @return Stacklight IP address (empty string if not connected)
     */
     String initStacklight(const char * ssid, const char * password, int retries = 10) {
@@ -183,4 +185,23 @@ namespace Stacklight
         }
         return ip;
     }
+}
+
+enum StacklightState {
+  STACKLIGHT_NOT_FOUND,
+  STACKLIGHT_ONLINE,
+  STACKLIGHT_PAIRED,
+};
+
+String stacklightStateToString (StacklightState state) {
+  switch (state) {
+    case STACKLIGHT_NOT_FOUND:
+      return "STACKLIGHT_NOT_FOUND";
+    case STACKLIGHT_ONLINE:
+      return "STACKLIGHT_ONLINE";
+    case STACKLIGHT_PAIRED:
+      return "STACKLIGHT_PAIRED";
+    default:
+      return "UNKNOWN";
+  }
 }


### PR DESCRIPTION
An attempt to make things more readable by separating concerns into separate files. This involves moving enums and associated functions out of the main deployable example file. 

Additionally, this adds a RAII class to help manage getting frames from the camera in the main loop. While this doesn't put a formal lock on the frame, it does guarantee that at the end of each loop the frame is properly released preventing errors from successive calls to esp_camera_fb_get between loops 